### PR TITLE
README appears to not use correct identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ module.exports = function(el) {
 };
 ```
 
-Now whenever you add an element with `data-wt="popup"` to the DOM, a click listener will be bound:
+Now whenever you add an element with `data-wt="alert"` to the DOM, a click listener will be bound:
 
 ```
-var content = $.get(someUrl); // Contains a "popup" block
-$('body').append(content); // "popup" block is initialized automatically
+var content = $.get(someUrl); // Contains an "alert" block
+$('body').append(content); // "alert" block is initialized automatically
 ```
 
 You can access the return value of the initialization function through your `Regulator` instance:
 
 ```
-myRegulator.withController($("[data-wt='AlertButton']"), function(controller) {
+myRegulator.withController($("[data-wt='alert']"), function(controller) {
   controller.triggerAlert();
 });
 ```


### PR DESCRIPTION
not 100% on this since I only read the readme, but it appears that
`data-wt="alert"` defines the identifier as `alert`. But in further
sections of the toy example, `alert` appears to be switched out for
`popup` in one case and `AlertButton` in another.

Looks like a few README edit committs may have jumbled a few versions of
the opening example together.